### PR TITLE
BaSP-TG-79: Timesheets hotfix / TG-40: Super Admins hotfix 

### DIFF
--- a/src/controllers/superAdmins.js
+++ b/src/controllers/superAdmins.js
@@ -3,7 +3,9 @@ import SuperAdmins from '../models/SuperAdmins';
 const getAllSuperAdmins = async (req, res) => {
   try {
     const result = await SuperAdmins.find(req.query);
-    const message = result.length ? 'Super admins found' : 'There are no super admins';
+    const message = result.length
+      ? 'Super admins found'
+      : 'There are no super admins';
 
     if (Object.keys(req.query).length !== 0 && result.length === 0) {
       throw new Error('Super admin not found');
@@ -63,7 +65,7 @@ const createSuperAdmin = async (req, res) => {
 
     const result = await superAdmin.save();
     return res.status(201).json({
-      message: 'Super admin created succesfully',
+      message: 'Super admin created successfully',
       data: result,
       error: false,
     });
@@ -89,7 +91,9 @@ const deleteSuperAdmin = async (req, res) => {
       error: false,
     });
   } catch (error) {
-    const statusCode = error.message.includes('Super admin not found') ? 404 : 400;
+    const statusCode = error.message.includes('Super admin not found')
+      ? 404
+      : 400;
     return res.status(statusCode).json({
       message: error.toString(),
       data: undefined,
@@ -100,7 +104,11 @@ const deleteSuperAdmin = async (req, res) => {
 
 const updateSuperAdmin = async (req, res) => {
   try {
-    const result = await SuperAdmins.findByIdAndUpdate(req.params.id, req.body);
+    const result = await SuperAdmins.findByIdAndUpdate(
+      req.params.id,
+      req.body,
+      { new: true },
+    );
     if (result === null) {
       throw new Error("Super admin doesn't exist");
     }

--- a/src/validations/tasks.js
+++ b/src/validations/tasks.js
@@ -18,7 +18,7 @@ const validateCreation = (req, res, next) => {
 };
 const validateEdit = (req, res, next) => {
   const tasksEditValidation = Joi.object({
-    description: Joi.string().min(3).max(50).required(),
+    description: Joi.string().min(3).max(50),
   });
 
   const validation = tasksEditValidation.validate(req.body);

--- a/src/validations/timesheets.js
+++ b/src/validations/timesheets.js
@@ -24,12 +24,12 @@ const validateCreation = (req, res, next) => {
 
 const validateEdition = (req, res, next) => {
   const timeSheetsValidations = Joi.object({
-    description: Joi.string().min(5).max(100).required(),
-    date: Joi.date().required(),
-    task: Joi.string().required(),
-    hours: Joi.number().required(),
-    project: Joi.string().required(),
-    employee: Joi.string().required(),
+    description: Joi.string().min(5).max(100),
+    date: Joi.date(),
+    task: Joi.string(),
+    hours: Joi.number(),
+    project: Joi.string(),
+    employee: Joi.string(),
   });
 
   const validation = timeSheetsValidations.validate(req.body, { abortEarly: false });


### PR DESCRIPTION
Timesheets hotfix:
Deleted the".required" from all edit schema contraints on Timesheet's validatons.

Super Admins TG-40 bug fix:
Add "{ new: true }" on Super Admin's controllers for the response to send updated information.